### PR TITLE
fix: build with latest gdext

### DIFF
--- a/addons/godot_rust_yaml/rust/src/lib.rs
+++ b/addons/godot_rust_yaml/rust/src/lib.rs
@@ -1,18 +1,20 @@
 
 use godot::engine::Json;
 use godot::prelude::*;
-use godot::builtin::GodotString;
+use godot::obj::cap::GodotDefault;
+use godot::builtin::GString;
 struct GodotRustYAML;
 #[gdextension]
 unsafe impl ExtensionLibrary for GodotRustYAML {}
 
 #[derive(GodotClass)]
-struct YAML {
-}
+struct YAML;
+impl GodotDefault for YAML {}
+
 #[godot_api]
 impl YAML {
     #[func]
-    fn parse(str: GodotString) -> Variant {
+    fn parse(str: GString) -> Variant {
         let input: String = str.to_string();
         let yaml_parse_result: Result<serde_json::Value, serde_yaml::Error> = serde_yaml::from_str(&input.replace("	", "   "));
         let json_value = match yaml_parse_result {
@@ -20,19 +22,19 @@ impl YAML {
             Err(error) => return Variant::from(format!("Problem parsing the YAML: {:?}", error)),
         };
         let json_string = serde_json::to_string(&json_value).unwrap();
-        return Json::parse_string(GodotString::from(json_string));
+        return Json::parse_string(GString::from(json_string));
     }
 
     #[func]
-    fn to_string(input: Dictionary) -> GodotString {
+    fn to_string(input: Dictionary) -> GString {
         let json_string = Json::stringify(Variant::from(input));
         let input: String = json_string.to_string();
         let json_parse_result: Result<serde_json::Value, serde_json::Error> = serde_json::from_str(&input);
         let yaml_value = match json_parse_result {
             Ok(parsed) => parsed,
-            Err(error) => return GodotString::from(format!("Problem parsing the dictionary: {:?}", error)),
+            Err(error) => return GString::from(format!("Problem parsing the dictionary: {:?}", error)),
         };
         let yaml_string = serde_yaml::to_string(&yaml_value).unwrap();
-        return GodotString::from(yaml_string);
+        return GString::from(yaml_string);
     }
 }


### PR DESCRIPTION
Currently doesn't build with the latest gdext (master).
I don't know anything about Rust so I did the quickest patch possible.

Works/Tested on Arch x86_64 with cargo 1.77.2, Godot 4.2 and gdext master